### PR TITLE
Add coding standard packages to dev tooling together with PHP CS Fixer

### DIFF
--- a/default.json
+++ b/default.json
@@ -54,6 +54,8 @@
                 "ergebnis/phpstan-rules",
                 "infection/infection",
                 "kubawerlos/php-cs-fixer-custom-fixers",
+                "lendable/cards-code-style-rules",
+                "lendable/central-platform-dev-tools",
                 "lendable/composer-license-checker",
                 "mikey179/vfsstream",
                 "php-cs-fixer/shim",


### PR DESCRIPTION
![image](https://github.com/Lendable/renovate-config/assets/1897953/1a5de46b-4c3b-4800-8ac7-ec8984a59a5d)

v1.1.1 of dev-tools require php-cs-fixer ^3.18 but there’s 3.17 installed locally… so it stays on v1.1.0 of dev-tools, but it still claims it’s v1.1.1
