### PR TITLE
Use rangeStrategy bump for Docker

### DIFF
--- a/default.json
+++ b/default.json
@@ -24,7 +24,8 @@
         {
             "matchManagers": ["docker-compose", "dockerfile"],
             "enabled": true,
-            "groupName": "docker"
+            "groupName": "docker",
+            "rangeStrategy": "bump"
         },
         {
             "matchManagers": ["composer"],


### PR DESCRIPTION
Updates to Dockerfile / docker-composer require the version constraint to be bumped, it's currently inheriting in-range which does nothing.