### PR TITLE
Don't pin composer/composer

### DIFF
--- a/default.json
+++ b/default.json
@@ -24,8 +24,17 @@
         {
             "matchManagers": ["docker-compose", "dockerfile"],
             "enabled": true,
-            "groupName": "docker",
+            "groupName": "Docker",
             "rangeStrategy": "bump"
+        },
+        {
+            "matchManagers": ["docker-compose", "dockerfile"],
+            "enabled": true,
+            "groupName": "Docker (unpinned)",
+            "groupSlug": "docker-unpinned",
+            "rangeStrategy": "bump",
+            "matchPackageNames": ["composer/composer"],
+            "pinDigests": false
         },
         {
             "matchManagers": ["composer"],


### PR DESCRIPTION
The `composer/composer` Docker image appears to have new pushes for all (current?) tags being re-pushed every time.

Leaving this as a draft for now, will monitor and see if this is entirely correct.