### PR TITLE
chore(DEVOPS-7314): migrate to gha scale sets

### DIFF
--- a/.github/workflows/syntax-validation.yml
+++ b/.github/workflows/syntax-validation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: [ 'lendable-medium-dind-x64-linux' ]
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
[DEVOPS-7314]

We are migrating to GHA ScaleSets - the new version of self-hosted GitHub runners. Please verify the changes:
1. It is using only single label for targeting like that - `[ 'lendable-small-arm64-linux' ]` . If possible follow literally for better future migration experience.
2. For each runner type we have both `arm64` and `x64` variants. Please try to run any generic jobs on arm runners. They offer better price to performance ratio.
3. You can run standard and container jobs on those runners. If you have problems - `#devops-help-desk`. Last resort Dind type runners.
4. Use Dind types `[ 'lendable-medium-dind-x64-linux' ]` only when you need to run `docker`. If your container jobs don't run in standard you can try them here.


[DEVOPS-7314]: https://lendable-uk.atlassian.net/browse/DEVOPS-7314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ