### PR TITLE
Use sha-pinning for github actions versions

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,7 +5,8 @@
         ":enableVulnerabilityAlerts",
         ":semanticCommitsDisabled",
         ":prHourlyLimitNone",
-        ":prImmediately"
+        ":prImmediately",
+        "helpers:pinGitHubActionDigests"
     ],
     "automerge": true,
     "automergeStrategy": "squash",


### PR DESCRIPTION
As described at https://docs.renovatebot.com/upgrade-best-practices/#extends-helperspingithubactiondigests - should use `actions/checkout@<sha1>` type versions.