### PR TITLE
chore(DEVOPS-7807): Add min release age to renovate github action updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -192,6 +192,15 @@
             "rangeStrategy": "bump"
         },
         {
+            "matchManagers": ["github-actions"],
+            "matchPackagePatterns": ["^lendable/", "^Lendable/"],
+            "enabled": true,
+            "minimumReleaseAge": "1 day",
+            "groupName": "GitHub Actions Lendable dependencies",
+            "groupSlug": "github-actions",
+            "rangeStrategy": "bump"
+        },
+        {
             "matchManagers": ["poetry"],
             "enabled": true,
             "groupName": "Poetry dependencies",

--- a/default.json
+++ b/default.json
@@ -186,7 +186,7 @@
         {
             "matchManagers": ["github-actions"],
             "enabled": true,
-            "minimumReleaseAge": "5 days",
+            "minimumReleaseAge": "3 days",
             "groupName": "GitHub Actions dependencies",
             "groupSlug": "github-actions",
             "rangeStrategy": "bump"

--- a/default.json
+++ b/default.json
@@ -186,6 +186,7 @@
         {
             "matchManagers": ["github-actions"],
             "enabled": true,
+            "minimumReleaseAge": "5 days",
             "groupName": "GitHub Actions dependencies",
             "groupSlug": "github-actions",
             "rangeStrategy": "bump"


### PR DESCRIPTION
### Changes

For GitHub Action updates, set min release age to 3 days.

`Time required before a new release is considered stable.`

This should reduce the risk of upgrading to a bad release.

For internal Lendable Actions, set to 1 day