### PR TITLE
Further updates to GHA checks

### DIFF
--- a/default.json
+++ b/default.json
@@ -187,6 +187,7 @@
             "matchManagers": ["github-actions"],
             "enabled": true,
             "minimumReleaseAge": "3 days",
+            "internalChecksFilter": "strict",
             "groupName": "GitHub Actions dependencies",
             "groupSlug": "github-actions",
             "rangeStrategy": "bump"
@@ -195,7 +196,6 @@
             "matchManagers": ["github-actions"],
             "matchPackagePatterns": ["^lendable/", "^Lendable/"],
             "enabled": true,
-            "minimumReleaseAge": "1 day",
             "groupName": "GitHub Actions Lendable dependencies",
             "groupSlug": "github-actions",
             "rangeStrategy": "bump"


### PR DESCRIPTION
* Set GHA updates to strict so PRs aren't open until they are ready: https://docs.renovatebot.com/configuration-options/#internalchecksfilter
* Remove the wait on internal checks