### PR TITLE
feat: Exclude Lendable actions from digest pinning

### DIFF
--- a/default.json
+++ b/default.json
@@ -201,6 +201,11 @@
             "rangeStrategy": "bump"
         },
         {
+            "matchDepTypes": ["action"],
+            "matchPackagePatterns": ["lendable/*", "Lendable/*"],
+            "pinDigests": false
+        },
+        {
             "matchManagers": ["poetry"],
             "enabled": true,
             "groupName": "Poetry dependencies",


### PR DESCRIPTION
As part of the resolution to the tj-actions incident, we enabled digest pinning for all github actions.  But this is not required for trusted internal actions and should be disabled by default.