### PR TITLE
fix: no minimum age for lendable gh actions deps

### DIFF
--- a/default.json
+++ b/default.json
@@ -198,7 +198,8 @@
             "enabled": true,
             "groupName": "GitHub Actions Lendable dependencies",
             "groupSlug": "github-actions",
-            "rangeStrategy": "bump"
+            "rangeStrategy": "bump",
+            "internalChecksFilter": "none"
         },
         {
             "matchDepTypes": ["action"],


### PR DESCRIPTION
Lendable GH workflows are getting stuck in pending rather than updated when tagged, I think this should prevent this (internalChecksFilter only relates to the minimum age check currently)

<img width="827" alt="Screenshot 2025-04-29 at 08 18 09" src="https://github.com/user-attachments/assets/03f53b2c-e384-49cb-b911-13cef4b4c678" />
