### PR TITLE
don't override rangeStrategy for golang

### DIFF
--- a/default.json
+++ b/default.json
@@ -188,7 +188,6 @@
             "matchDepTypes": ["golang"],
             "groupName": "Go dependencies",
             "groupSlug": "go",
-            "rangeStrategy": "bump",
             "enabled": true
         },
         {


### PR DESCRIPTION
We should let the strategy for bumping go dependencies be the default see: https://github.com/renovatebot/renovate/pull/16682

With the current setup, renovate tries to bump go to patch versions, which doesn't work, see: https://github.com/Lendable/event-prototype/actions/runs/15118541447/job/42495251047?pr=6#step:7:17